### PR TITLE
ENH: Update vtkOpenGL classes for OpenGL2 backend, add float uniform setting

### DIFF
--- a/Libs/vtkAddon/vtkOpenGLShaderComputation.h
+++ b/Libs/vtkAddon/vtkOpenGLShaderComputation.h
@@ -20,13 +20,15 @@
 #ifndef __vtkOpenGLShaderComputation_h
 #define __vtkOpenGLShaderComputation_h
 
+// VTK includes
+#include "vtk_glew.h"
+#include "vtkAddon.h"
 #include "vtkImageData.h"
 #include "vtkRenderWindow.h"
+#include "vtkVariant.h"
 
-class vtkImageData;
-
-#include "vtkAddon.h"
-
+// STD includes
+#include <map>
 
 class VTK_ADDON_EXPORT vtkOpenGLShaderComputation : public vtkObject
 {
@@ -64,6 +66,10 @@ public:
   // renders to the current framebuffer configuration
   // Slice will be passed as a uniform float
   void Compute(float slice=0.);
+
+  // Description:
+  // Add a uniform value TODO: support types other than float
+  void SetUniform(std::string name, float uniform);
 
   // Description:
   // Copy the framebuffer pixels into the result image
@@ -111,6 +117,8 @@ private:
   vtkTypeUInt32 DepthRenderbufferID;
 
   vtkRenderWindow *RenderWindow;
+
+  std::map<std::string, vtkVariant> Uniforms;
 };
 
 #endif

--- a/Libs/vtkAddon/vtkOpenGLTextureImage.h
+++ b/Libs/vtkAddon/vtkOpenGLTextureImage.h
@@ -24,7 +24,10 @@
 #ifndef __vtkOpenGLTextureImage_h
 #define __vtkOpenGLTextureImage_h
 
+#include "vtk_glew.h"
+
 #include "vtkOpenGLShaderComputation.h"
+#include "vtkOpenGL.h"
 
 #include "vtkImageData.h"
 
@@ -67,6 +70,11 @@ public:
   vtkSetMacro(Interpolate, int);
 
   // Description:
+  // Texture wrap mode (ClampToEdge, MirroredRepeat)
+  vtkGetMacro(TextureWrap, int);
+  vtkSetMacro(TextureWrap, int);
+
+  // Description:
   // Make the image data available as GL_TEXTUREn
   // where n is the texture unit.  There are at least
   // GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, which is variable
@@ -100,6 +108,12 @@ public:
     };
   void AttachAsDrawTarget(int layer=0, int attachement=0, int attachmentIndex=0);
 
+  enum TextureWrap
+    {
+    ClampToEdge,
+    MirroredRepeat,
+    };
+
   // Description:
   // Read the texture data back into the image data
   // (assumes it has been written as a target)
@@ -108,6 +122,7 @@ public:
   // is the right size for the data).
   void ReadBack();
 
+  static GLenum vtkScalarTypeToGLType(int vtk_scalar_type);
   // Description:
   // TODO: options for min and mag filter, wrapping...
 
@@ -124,6 +139,7 @@ private:
   vtkTypeUInt32 TextureName;
   int Interpolate;
   unsigned long TextureMTime;
+  int TextureWrap;
 
 };
 


### PR DESCRIPTION
@pieper Here is the modified version of CommonGL that I've been using.

One of the things that I did was add a rudimentary system for setting uniform variables on the vtkOpenGLShaderComputation object. (Only works with float currently)

There are a number of other changes as well, although I'm not sure how many of them are actually necessary. (Unfortunately my base OpenGL is not very good)